### PR TITLE
支持VC继承体系时，接口替换问题

### DIFF
--- a/YJ3DTouch.xcodeproj/project.pbxproj
+++ b/YJ3DTouch.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				INFOPLIST_FILE = YJ3DTouch/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = hyman.YJ3DTouch;
@@ -323,6 +324,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				INFOPLIST_FILE = YJ3DTouch/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = hyman.YJ3DTouch;

--- a/YJ3DTouch/YJ3DTouch/YJ3DTouchUtil.h
+++ b/YJ3DTouch/YJ3DTouch/YJ3DTouchUtil.h
@@ -12,4 +12,6 @@
 
 + (void)safeSwizzleOriginMethod:(SEL)origSel withTargetMethod:(SEL)altSel forClass:(Class)cls;
 
++ (void)dynamicProcessClass:(Class)cls oriSel:(SEL)oriSel altSel:(SEL)altSel oriImp:(IMP)oriImp altImp:(IMP)altImp;
+
 @end


### PR DESCRIPTION
如果VC是有基类，有继承时，多次替换，会将基类的函数指针替换乱掉。目前的实现是动态的新增接口，在替换时，每个类都有自己的接口实现。